### PR TITLE
Remove superfluous `Monoid m` constraint

### DIFF
--- a/src/Generic/Applicative/Idiom.hs
+++ b/src/Generic/Applicative/Idiom.hs
@@ -88,7 +88,7 @@ data Terminal
 instance (Applicative f, Monoid m) => Idiom Terminal f (Const m) where
   idiom :: f ~> Const m
   idiom = mempty
-instance (Applicative f, Monoid m) => Idiom Terminal f Proxy where
+instance (Applicative f) => Idiom Terminal f Proxy where
   idiom :: f ~> Proxy
   idiom = mempty
 


### PR DESCRIPTION
There is a `Monoid m` constraint in the `Idiom Terminal f Proxy` instance but `m` isn't mentioned anywhere in the instance. This looks like a copy/paste error from the `Const m` instance.
