### PR TITLE
Enable FlexibleContexts

### DIFF
--- a/src/Generic/Applicative/Idiom.hs
+++ b/src/Generic/Applicative/Idiom.hs
@@ -3,6 +3,7 @@
 {-# Language DeriveFunctor            #-}
 {-# Language DerivingStrategies       #-}
 {-# Language EmptyDataDecls           #-}
+{-# Language FlexibleContexts         #-}
 {-# Language FlexibleInstances        #-}
 {-# Language InstanceSigs             #-}
 {-# Language MultiParamTypeClasses    #-}


### PR DESCRIPTION
Required by GHC 9.2.{1,2} for the `Idiom Dup`/`IdiomDup` instances:

```
src/Generic/Applicative/Idiom.hs:138:10: error:
    • Non type-variable argument
        in the constraint: IdiomDup (CheckIdiomDup g) f g
      (Use FlexibleContexts to permit this)
    • In the instance declaration for ‘Idiom Dup f g’
    |
138 | instance (Applicative f, Applicative g, IdiomDup (CheckIdiomDup g) f g) => Idiom Dup f g where
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Generic/Applicative/Idiom.hs:150:10: error:
    • Non type-variable argument
        in the constraint: IdiomDup (CheckIdiomDup g') g g'
      (Use FlexibleContexts to permit this)
    • In the instance declaration for ‘IdiomDup 'True f (Product g g')’
    |
150 | instance (f ~ g, IdiomDup (CheckIdiomDup g') g g') => IdiomDup 'True f (Product g g') where
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```